### PR TITLE
Update message payloads

### DIFF
--- a/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.claim.complete.md
+++ b/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.claim.complete.md
@@ -11,7 +11,7 @@ Update `commsAddresses` to your own email address.
     "data": {
         "crn": "1050000000",
         "sbi": "105000000",
-        "sourceSystem": "AHWP",
+        "sourceSystem": "ahwp",
         "notifyTemplateId": "27ccdee6-d823-4adf-8958-68549f913747",
         "commsType": "email",
         "commsAddresses": [

--- a/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.claim.follow.up.md
+++ b/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.claim.follow.up.md
@@ -11,7 +11,7 @@ Update `commsAddresses` to your own email address.
     "data": {
         "crn": "1050000000",
         "sbi": "105000000",
-        "sourceSystem": "AHWP",
+        "sourceSystem": "ahwp",
         "notifyTemplateId": "bf194e44-0dab-4c0e-ba9d-55bce357d3fc",
         "commsType": "email",
         "commsAddresses": [

--- a/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.claim.review.md
+++ b/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.claim.review.md
@@ -11,7 +11,7 @@ Update `commsAddresses` to your own email address.
     "data": {
         "crn": "1050000000",
         "sbi": "105000000",
-        "sourceSystem": "AHWP",
+        "sourceSystem": "ahwp",
         "notifyTemplateId": "d8017132-1909-4bee-b604-b07e8081dc82",
         "commsType": "email",
         "commsAddresses": [

--- a/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.user.existing.md
+++ b/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.user.existing.md
@@ -11,7 +11,7 @@ Update `commsAddresses` to your own email address.
     "data": {
         "crn": "1050000000",
         "sbi": "105000000",
-        "sourceSystem": "AHWP",
+        "sourceSystem": "ahwp",
         "notifyTemplateId": "0de30a2d-62bc-47b2-946e-6c6588887c4f",
         "commsType": "email",
         "commsAddresses": [

--- a/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.user.new.md
+++ b/resources/test-message-payloads/ahwp/uk.gov.fcp.ahwp.user.new.md
@@ -11,7 +11,7 @@ Update `commsAddresses` to your own email address.
     "data": {
         "crn": "1050000000",
         "sbi": "105000000",
-        "sourceSystem": "AHWP",
+        "sourceSystem": "ahwp",
         "notifyTemplateId": "2f9b1e0e-b678-481c-839e-892ebf42fddf",
         "commsType": "email",
         "commsAddresses": [


### PR DESCRIPTION
Created this PR to ensure our example message payloads for local development and testing are up to date as they will currently throw the following error based on the value for `sourceSystem` which is currently uppercase in all of the example payloads when the regex (`/^[a-z0-9-_]+$/`) requires it to be lowercase:
```
"sourceSystem": "AHWP",
    "statusDetails": {
      "errors": [
        {
          "error": "ValidationError",
          "message": "\"data.sourceSystem\" with value \"AHWP\" fails to match the required pattern: /^[a-z0-9-_]+$/"
        }
      ],
      "status": "validation-failure"
    }
```